### PR TITLE
fetch all teams and filter before sending result

### DIFF
--- a/pkg/teamkatalogen/teamkatalogen.go
+++ b/pkg/teamkatalogen/teamkatalogen.go
@@ -24,7 +24,6 @@ type TeamkatalogenResponse struct {
 			Ui string `json:"ui"`
 		} `json:"links"`
 		NaisTeams []string `json:"naisTeams"`
-		Tags      []string `json:"tags"`
 	} `json:"content"`
 }
 


### PR DESCRIPTION
jeg sliter litt med å teste dette lokalt, så jeg håper at jeg treffer riktig endepunkt her, haha.
idéen på fronten er ish at man velger et naisteam (aura@nav.no tror jeg strengen egentlig er, den kan kanskje kaste bort @nav.no før den spør backenden), så brukes det til å spørre om et teamkatalogen-team fins med det teamnavnet. jeg har nok overkomplisert litt her, og følger ish frontendkoden til teamkatalogen når det blir gjort et søk der.

vi kan kanskje alltid anta at det er et team som eier en ressurs, og at teamnavn@nav.no vil alltid være representert som teamnavn  i naisTeams-feltet til minst ett team i teamkatalogen-responsen. så kan vi kanskje heller kun filtrere på det.. :thinking: 