### PR TITLE
update quarto with multiple files

### DIFF
--- a/e2etests/quarto_test.go
+++ b/e2etests/quarto_test.go
@@ -276,7 +276,7 @@ func prepareQuartoTests(ctx context.Context) (uuid.UUID, error) {
 func createMultipartForm(html string) (*bytes.Buffer, string, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
-	part, err := writer.CreateFormFile("file", "index.html")
+	part, err := writer.CreateFormFile("index.html", "index.html")
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/gcs/gcs.go
+++ b/pkg/gcs/gcs.go
@@ -57,7 +57,6 @@ func (c *Client) GetObject(ctx context.Context, path string) (*storage.ObjectAtt
 }
 
 func (c *Client) UploadFile(ctx context.Context, name string, file multipart.File) error {
-	fmt.Print(name)
 	datab, err := ioutil.ReadAll(file)
 	if err != nil {
 		c.log.WithError(err).Errorf("reading uploaded file %v", name)

--- a/pkg/quarto/http.go
+++ b/pkg/quarto/http.go
@@ -174,11 +174,9 @@ func (h *Handler) uploadFile(ctx context.Context, objPath string, fileHeader []*
 	for _, f := range fileHeader {
 		fileFullPath:= f.Filename
 
-		h.log.Printf(f.Filename)
 		//try to extract full path from content-disposition header
 		_, params, err := mime.ParseMediaType(f.Header.Get("Content-Disposition"))
 		if err == nil{
-			h.log.Print(params)
 			pathInCDHeader := params["name"]
 			if pathInCDHeader != "" {
 				fileFullPath = pathInCDHeader
@@ -190,7 +188,7 @@ func (h *Handler) uploadFile(ctx context.Context, objPath string, fileHeader []*
 			return err
 		}
 		
-		h.log.Printf("file full path %v", objPath+"/"+fileFullPath)
+		h.log.Printf("upload quarto file full path %v", objPath+"/"+fileFullPath)
 
 		if err := h.gcsClient.UploadFile(ctx, objPath+"/"+fileFullPath, file); err != nil {
 			return err

--- a/pkg/quarto/http.go
+++ b/pkg/quarto/http.go
@@ -187,6 +187,9 @@ func (h *Handler) uploadFile(ctx context.Context, objPath string, fileHeader []*
 		if err != nil {
 			return err
 		}
+		
+		h.log.Printf("file full path %v", fileFullPath)
+
 		if err := h.gcsClient.UploadFile(ctx, objPath+"/"+fileFullPath, file); err != nil {
 			return err
 		}

--- a/pkg/quarto/http.go
+++ b/pkg/quarto/http.go
@@ -174,6 +174,7 @@ func (h *Handler) uploadFile(ctx context.Context, objPath string, fileHeader []*
 	for _, f := range fileHeader {
 		fileFullPath:= f.Filename
 
+		h.log.Printf(f.Filename)
 		//try to extract full path from content-disposition header
 		_, params, err := mime.ParseMediaType(f.Header.Get("Content-Disposition"))
 		if err == nil{

--- a/pkg/quarto/http.go
+++ b/pkg/quarto/http.go
@@ -177,6 +177,7 @@ func (h *Handler) uploadFile(ctx context.Context, objPath string, fileHeader []*
 		//try to extract full path from content-disposition header
 		_, params, err := mime.ParseMediaType(f.Header.Get("Content-Disposition"))
 		if err == nil{
+			h.log.Print(params)
 			pathInCDHeader := params["name"]
 			if pathInCDHeader != "" {
 				fileFullPath = pathInCDHeader
@@ -188,7 +189,7 @@ func (h *Handler) uploadFile(ctx context.Context, objPath string, fileHeader []*
 			return err
 		}
 		
-		h.log.Printf("file full path %v", fileFullPath)
+		h.log.Printf("file full path %v", objPath+"/"+fileFullPath)
 
 		if err := h.gcsClient.UploadFile(ctx, objPath+"/"+fileFullPath, file); err != nil {
 			return err


### PR DESCRIPTION
Mainly modified two things:
1) delete existing quarto files when update
2) support directory structure when update. the directory information should be included in the request header which is supported by most modern languages, for example:

```
import os
import requests

def upload_files(url, files):
    multipart_form_data = {}
    for file_path in files:
        file_name = os.path.basename(file_path)
        with open(file_path, 'rb') as file:
            # Read the file contents and store them in the dictionary
            file_contents = file.read()
            multipart_form_data[file_path] = (file_name, file_contents)

    # Send the request with all files in the dictionary
    response = requests.put(url, files=multipart_form_data)
    return response

if __name__ == "__main__":
    # Replace this URL with your server's URL
    server_url = "http://localhost:8080/quarto/update/d537d5e8-3b7e-4936-a0d1-62aa07315359"

    # A list of file paths to be uploaded
    files_to_upload = [
        "quartomock/updated/indexNew.html",
        "quartomock/updated/sd1/android-chrome-192x192.png",
        "quartomock/updated/sd2/knorten.svg"
    ]

    response = upload_files(server_url, files_to_upload)
    
    print(response.status_code)
    print(response.text)
```