### PR TITLE
feat: give users the option to rotate team tokens

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+func RotateNadaToken(ctx context.Context, team string) *APIError {
+	if team == "" {
+		return NewAPIError(http.StatusBadRequest, errors.New("no team provided"))
+	}
+	if err := ensureUserInGroup(ctx, team+"@nav.no"); err != nil {
+		return NewAPIError(http.StatusUnauthorized, err)
+	}
+
+	return DBErrorToAPIError(querier.RotateNadaToken(ctx, team))
+}

--- a/pkg/database/gensql/querier.go
+++ b/pkg/database/gensql/querier.go
@@ -110,6 +110,7 @@ type Querier interface {
 	ReplaceStoriesTag(ctx context.Context, arg ReplaceStoriesTagParams) error
 	RestoreMetabaseMetadata(ctx context.Context, datasetID uuid.UUID) error
 	RevokeAccessToDataset(ctx context.Context, id uuid.UUID) error
+	RotateNadaToken(ctx context.Context, team string) error
 	Search(ctx context.Context, arg SearchParams) ([]SearchRow, error)
 	SetDatasourceDeleted(ctx context.Context, id uuid.UUID) error
 	SetJoinableViewDeleted(ctx context.Context, id uuid.UUID) error

--- a/pkg/database/gensql/team.sql.go
+++ b/pkg/database/gensql/team.sql.go
@@ -116,3 +116,14 @@ func (q *Queries) GetTeamFromNadaToken(ctx context.Context, token uuid.UUID) (st
 	err := row.Scan(&team)
 	return team, err
 }
+
+const rotateNadaToken = `-- name: RotateNadaToken :exec
+UPDATE nada_tokens
+SET token = gen_random_uuid()
+WHERE team = $1
+`
+
+func (q *Queries) RotateNadaToken(ctx context.Context, team string) error {
+	_, err := q.db.ExecContext(ctx, rotateNadaToken, team)
+	return err
+}

--- a/pkg/database/queries/team.sql
+++ b/pkg/database/queries/team.sql
@@ -27,6 +27,11 @@ SELECT team
 FROM nada_tokens
 WHERE token = @token;
 
+-- name: RotateNadaToken :exec
+UPDATE nada_tokens
+SET token = gen_random_uuid()
+WHERE team = @team;
+
 -- name: DeleteNadaToken :exec
 DELETE FROM
     nada_tokens

--- a/pkg/database/repo_test.go
+++ b/pkg/database/repo_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -161,7 +160,6 @@ func TestRepo(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			fmt.Println(dp)
 			_, err = repo.GrantAccessToDataset(context.Background(), dp.ID, &ti, subj, "")
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/database/team.go
+++ b/pkg/database/team.go
@@ -40,6 +40,10 @@ func (r *Repo) GetNadaTokensForTeams(ctx context.Context, teams []string) ([]*mo
 	return tokens, nil
 }
 
+func (r *Repo) RotateNadaToken(ctx context.Context, team string) error {
+	return r.Querier.RotateNadaToken(ctx, team)
+}
+
 func (r *Repo) DeleteNadaToken(ctx context.Context, team string) error {
 	return r.Querier.DeleteNadaToken(ctx, team)
 }


### PR DESCRIPTION
Give the users the ability to rotate their team tokens in the event of e.g. token is compromized.