### PR TITLE
fix: set correct bigquery ref for pseudo datasets

### DIFF
--- a/pkg/graph/datasets.resolvers.go
+++ b/pkg/graph/datasets.resolvers.go
@@ -149,12 +149,11 @@ func (r *mutationResolver) CreateDataset(ctx context.Context, input models.NewDa
 		}
 	}
 
-	metadata, err := r.prepareBigQuery(ctx, input.BigQuery, pseudoBigQuery, dp.Owner.Group)
+	input, err = r.prepareBigQueryHandlePseudoView(ctx, input, pseudoBigQuery, dp.Owner.Group)
 	if err != nil {
 		return nil, err
 	}
 
-	input.Metadata = metadata
 	if input.Description != nil && *input.Description != "" {
 		*input.Description = html.EscapeString(*input.Description)
 	}


### PR DESCRIPTION
We need to store the correct reference for the pseudo dataset in our backend in order for access to be granted the pseudo dataset and not the underlying dataset