### PR TITLE
bug(nadatokens)

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -84,14 +84,14 @@ type UserInfo struct {
 	// accessRequests is a list of access requests where either the user or one of the users groups is owner.
 	AccessRequests []AccessRequest `json:"accessRequests"`
 
-	//accessRequestsAsGranter is a list of access requests where one of the users groups is obliged to handle.
+	// accessRequestsAsGranter is a list of access requests where one of the users groups is obliged to handle.
 	AccessRequestsAsGranter []AccessRequestForGranter `json:"accessRequestsAsGranter"`
 }
 
 func teamNamesFromGroups(groups auth.Groups) []string {
 	teams := []string{}
 	for _, g := range groups {
-		teams = append(teams, TrimNaisTeamPrefix(strings.Split(g.Email, "@")[0]))
+		teams = append(teams, auth.TrimNaisTeamPrefix(strings.Split(g.Email, "@")[0]))
 	}
 
 	return teams
@@ -174,7 +174,7 @@ func getUserData(ctx context.Context) (*UserInfo, *APIError) {
 	}
 
 	for _, grp := range user.GoogleGroups {
-		proj, ok := teamProjectsMapping.Get(TrimNaisTeamPrefix(grp.Email))
+		proj, ok := teamProjectsMapping.Get(auth.TrimNaisTeamPrefix(grp.Email))
 		if !ok {
 			continue
 		}
@@ -273,8 +273,4 @@ func pollySQLToGraphql(ctx context.Context, id uuid.NullUUID) (*Polly, error) {
 			URL:        pollyDoc.Url,
 		},
 	}, nil
-}
-
-func TrimNaisTeamPrefix(team string) string {
-	return strings.TrimPrefix(team, "nais-team-")
 }

--- a/pkg/auth/google_groups.go
+++ b/pkg/auth/google_groups.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/google"
@@ -76,4 +77,8 @@ func (g *GoogleGroupClient) Groups(ctx context.Context, email *string) (groups G
 	})
 
 	return groups, err
+}
+
+func TrimNaisTeamPrefix(team string) string {
+	return strings.TrimPrefix(team, "nais-team-")
 }

--- a/pkg/database/migrations/0085_remove_duplicate_nada_token_teams.sql
+++ b/pkg/database/migrations/0085_remove_duplicate_nada_token_teams.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+ALTER TABLE nada_tokens DROP CONSTRAINT nada_tokens_token_key;
+
+WITH without_naisteam_prefix AS (
+  SELECT REPLACE(team, 'nais-team-', '') as team, token FROM nada_tokens 
+  WHERE team LIKE 'nais-team-%'
+)
+
+INSERT INTO nada_tokens (team,token) (
+  SELECT team, token from without_naisteam_prefix
+) ON CONFLICT (team) DO
+UPDATE
+SET token=EXCLUDED.token;
+
+DELETE FROM nada_tokens WHERE team LIKE 'nais-team-%';
+
+ALTER TABLE nada_tokens ADD CONSTRAINT nada_tokens_token_key UNIQUE (token);

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -9,7 +9,6 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/google/uuid"
-	"github.com/navikt/nada-backend/pkg/api"
 	"github.com/navikt/nada-backend/pkg/auth"
 	bq "github.com/navikt/nada-backend/pkg/bigquery"
 	"github.com/navikt/nada-backend/pkg/database"
@@ -81,7 +80,7 @@ func New(repo *database.Repo, gcp Bigquery, gcpProjects *auth.TeamProjectsMappin
 }
 
 func (r *Resolver) ensureGroupOwnsGCPProject(ctx context.Context, group, projectID string) error {
-	groupProject, ok := r.gcpProjects.Get(api.TrimNaisTeamPrefix(group))
+	groupProject, ok := r.gcpProjects.Get(auth.TrimNaisTeamPrefix(group))
 	if !ok {
 		return ErrUnauthorized
 	}

--- a/pkg/story/http.go
+++ b/pkg/story/http.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/navikt/nada-backend/pkg/amplitude"
+	"github.com/navikt/nada-backend/pkg/auth"
 	"github.com/navikt/nada-backend/pkg/database"
 	"github.com/navikt/nada-backend/pkg/gcs"
 	"github.com/navikt/nada-backend/pkg/graph/models"
@@ -265,7 +266,7 @@ func (h *Handler) updateStory(w http.ResponseWriter, r *http.Request, next http.
 	}
 
 	group := strings.Split(story.Group, "@")[0]
-	dbToken, err := h.repo.GetNadaToken(r.Context(), group)
+	dbToken, err := h.repo.GetNadaToken(r.Context(), auth.TrimNaisTeamPrefix(group))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			h.log.Errorf("no nada token found for team %v, story id %v", story.Group, qID)


### PR DESCRIPTION
We periodically sync team names from nais console and they have removed the nais-team prefix from the slug name returned. On our end this has caused us to create multiple nada tokens for some teams created earlier. In addition the wrong team token is the one that has been visible for the user through the ui when logged in to markedsplassen.

The migration in this commit will ensure that each team only has one nada-token, and that this is the one that is shown in the ui for the user.