### PR TITLE
 bug(explore team products)

### DIFF
--- a/pkg/api/dataproducts.go
+++ b/pkg/api/dataproducts.go
@@ -58,10 +58,11 @@ type DatasetInDataproduct struct {
 }
 
 type DataproductOwner struct {
-	Group            string  `json:"group"`
-	TeamkatalogenURL *string `json:"teamkatalogenURL"`
-	TeamContact      *string `json:"teamContact"`
-	TeamID           *string `json:"teamID"`
+	Group            string     `json:"group"`
+	TeamkatalogenURL *string    `json:"teamkatalogenURL"`
+	TeamContact      *string    `json:"teamContact"`
+	TeamID           *string    `json:"teamID"`
+	ProductAreaID    *uuid.UUID `json:"productAreaID"`
 }
 
 type Dataproduct struct {
@@ -177,6 +178,7 @@ __loop_rows:
 					TeamkatalogenURL: nullStringToPtr(dprow.TeamkatalogenUrl),
 					TeamContact:      nullStringToPtr(dprow.TeamContact),
 					TeamID:           nullStringToPtr(dprow.TeamID),
+					ProductAreaID:    nullUUIDToUUIDPtr(dprow.PaID),
 				},
 			},
 		}

--- a/pkg/api/productareas.go
+++ b/pkg/api/productareas.go
@@ -176,6 +176,7 @@ func dataproductFromSQL(dp *gensql.DataproductWithTeamkatalogenView) *Dataproduc
 			TeamkatalogenURL: nullStringToPtr(dp.TeamkatalogenUrl),
 			TeamContact:      nullStringToPtr(dp.TeamContact),
 			TeamID:           nullStringToPtr(dp.TeamID),
+			ProductAreaID:    nullUUIDToUUIDPtr(dp.PaID),
 		},
 		Created:         dp.Created,
 		LastModified:    dp.LastModified,

--- a/pkg/database/gensql/dataproducts.sql.go
+++ b/pkg/database/gensql/dataproducts.sql.go
@@ -320,7 +320,7 @@ func (q *Queries) GetDataproductsByIDs(ctx context.Context, ids []uuid.UUID) ([]
 }
 
 const getDataproductsByProductArea = `-- name: GetDataproductsByProductArea :many
-SELECT id, name, description, "group", created, last_modified, tsv_document, slug, teamkatalogen_url, team_contact, team_id, team_name, pa_name
+SELECT id, name, description, "group", created, last_modified, tsv_document, slug, teamkatalogen_url, team_contact, team_id, team_name, pa_name, pa_id
 FROM dataproduct_with_teamkatalogen_view
 WHERE team_id = ANY($1::text[])
 ORDER BY created DESC
@@ -349,6 +349,7 @@ func (q *Queries) GetDataproductsByProductArea(ctx context.Context, teamID []str
 			&i.TeamID,
 			&i.TeamName,
 			&i.PaName,
+			&i.PaID,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/database/gensql/dataproducts_v2.sql.go
+++ b/pkg/database/gensql/dataproducts_v2.sql.go
@@ -42,7 +42,7 @@ func (q *Queries) GetDataproductKeywords(ctx context.Context, dpid uuid.UUID) ([
 }
 
 const getDataproductWithDatasetsBasic = `-- name: GetDataproductWithDatasetsBasic :many
-SELECT dp.id, dp.name, dp.description, "group", dp.created, dp.last_modified, dp.tsv_document, dp.slug, teamkatalogen_url, team_contact, team_id, team_name, pa_name, ds.id, ds.name, ds.description, pii, ds.created, ds.last_modified, type, ds.tsv_document, ds.slug, repo, keywords, dataproduct_id, anonymisation_description, target_user
+SELECT dp.id, dp.name, dp.description, "group", dp.created, dp.last_modified, dp.tsv_document, dp.slug, teamkatalogen_url, team_contact, team_id, team_name, pa_name, pa_id, ds.id, ds.name, ds.description, pii, ds.created, ds.last_modified, type, ds.tsv_document, ds.slug, repo, keywords, dataproduct_id, anonymisation_description, target_user
 FROM dataproduct_with_teamkatalogen_view dp LEFT JOIN datasets ds ON ds.dataproduct_id = dp.id
 WHERE dp.id = $1
 `
@@ -61,6 +61,7 @@ type GetDataproductWithDatasetsBasicRow struct {
 	TeamID                   sql.NullString
 	TeamName                 sql.NullString
 	PaName                   sql.NullString
+	PaID                     uuid.NullUUID
 	ID_2                     uuid.NullUUID
 	Name_2                   sql.NullString
 	Description_2            sql.NullString
@@ -100,6 +101,7 @@ func (q *Queries) GetDataproductWithDatasetsBasic(ctx context.Context, id uuid.U
 			&i.TeamID,
 			&i.TeamName,
 			&i.PaName,
+			&i.PaID,
 			&i.ID_2,
 			&i.Name_2,
 			&i.Description_2,
@@ -142,7 +144,7 @@ func (q *Queries) GetDataproductsNumberByTeam(ctx context.Context, teamID sql.Nu
 }
 
 const getDataproductsWithDatasets = `-- name: GetDataproductsWithDatasets :many
-SELECT dp.dp_id, dp.dp_name, dp.dp_description, dp.dp_group, dp.dp_created, dp.dp_last_modified, dp.dp_slug, dp.teamkatalogen_url, dp.team_contact, dp.team_id, dp.team_name, dp.pa_name, dp.ds_dp_id, dp.ds_id, dp.ds_name, dp.ds_description, dp.ds_created, dp.ds_last_modified, dp.ds_slug, dp.ds_keywords, dsrc.last_modified as "dsrc_last_modified"
+SELECT dp.dp_id, dp.dp_name, dp.dp_description, dp.dp_group, dp.dp_created, dp.dp_last_modified, dp.dp_slug, dp.teamkatalogen_url, dp.team_contact, dp.team_id, dp.team_name, dp.pa_name, dp.pa_id, dp.ds_dp_id, dp.ds_id, dp.ds_name, dp.ds_description, dp.ds_created, dp.ds_last_modified, dp.ds_slug, dp.ds_keywords, dsrc.last_modified as "dsrc_last_modified"
 FROM dataproduct_view dp
 LEFT JOIN datasource_bigquery dsrc ON dsrc.dataset_id = dp.ds_id
 WHERE (array_length($1::uuid[], 1) IS NULL OR dp_id = ANY ($1))
@@ -167,6 +169,7 @@ type GetDataproductsWithDatasetsRow struct {
 	TeamID           sql.NullString
 	TeamName         sql.NullString
 	PaName           sql.NullString
+	PaID             uuid.NullUUID
 	DsDpID           uuid.NullUUID
 	DsID             uuid.NullUUID
 	DsName           sql.NullString
@@ -200,6 +203,7 @@ func (q *Queries) GetDataproductsWithDatasets(ctx context.Context, arg GetDatapr
 			&i.TeamID,
 			&i.TeamName,
 			&i.PaName,
+			&i.PaID,
 			&i.DsDpID,
 			&i.DsID,
 			&i.DsName,
@@ -224,7 +228,7 @@ func (q *Queries) GetDataproductsWithDatasets(ctx context.Context, arg GetDatapr
 }
 
 const getDataproductsWithDatasetsAndAccessRequests = `-- name: GetDataproductsWithDatasetsAndAccessRequests :many
-SELECT dp.dp_id, dp.dp_name, dp.dp_description, dp.dp_group, dp.dp_created, dp.dp_last_modified, dp.dp_slug, dp.teamkatalogen_url, dp.team_contact, dp.team_id, dp.team_name, dp.pa_name, dp.ds_dp_id, dp.ds_id, dp.ds_name, dp.ds_description, dp.ds_created, dp.ds_last_modified, dp.ds_slug, dp.ds_keywords, dsrc.last_modified as "dsrc_last_modified",
+SELECT dp.dp_id, dp.dp_name, dp.dp_description, dp.dp_group, dp.dp_created, dp.dp_last_modified, dp.dp_slug, dp.teamkatalogen_url, dp.team_contact, dp.team_id, dp.team_name, dp.pa_name, dp.pa_id, dp.ds_dp_id, dp.ds_id, dp.ds_name, dp.ds_description, dp.ds_created, dp.ds_last_modified, dp.ds_slug, dp.ds_keywords, dsrc.last_modified as "dsrc_last_modified",
  dar.id as "dar_id", dar.dataset_id as "dar_dataset_id", dar.subject as "dar_subject", dar.owner as "dar_owner",
   dar.expires as "dar_expires", dar.status as "dar_status", dar.granter as "dar_granter", dar.reason as "dar_reason", 
   dar.closed as "dar_closed", dar.polly_documentation_id as "dar_polly_documentation_id", dar.created as "dar_created"
@@ -253,6 +257,7 @@ type GetDataproductsWithDatasetsAndAccessRequestsRow struct {
 	TeamID                  sql.NullString
 	TeamName                sql.NullString
 	PaName                  sql.NullString
+	PaID                    uuid.NullUUID
 	DsDpID                  uuid.NullUUID
 	DsID                    uuid.NullUUID
 	DsName                  sql.NullString
@@ -297,6 +302,7 @@ func (q *Queries) GetDataproductsWithDatasetsAndAccessRequests(ctx context.Conte
 			&i.TeamID,
 			&i.TeamName,
 			&i.PaName,
+			&i.PaID,
 			&i.DsDpID,
 			&i.DsID,
 			&i.DsName,

--- a/pkg/database/gensql/models.go
+++ b/pkg/database/gensql/models.go
@@ -173,6 +173,7 @@ type DataproductView struct {
 	TeamID           sql.NullString
 	TeamName         sql.NullString
 	PaName           sql.NullString
+	PaID             uuid.NullUUID
 	DsDpID           uuid.NullUUID
 	DsID             uuid.NullUUID
 	DsName           sql.NullString
@@ -197,6 +198,7 @@ type DataproductWithTeamkatalogenView struct {
 	TeamID           sql.NullString
 	TeamName         sql.NullString
 	PaName           sql.NullString
+	PaID             uuid.NullUUID
 }
 
 type Dataset struct {

--- a/pkg/database/migrations/0086_include_pa_id_in_dp_view.sql
+++ b/pkg/database/migrations/0086_include_pa_id_in_dp_view.sql
@@ -1,0 +1,76 @@
+-- +goose Up
+DROP VIEW dataproduct_view;
+DROP VIEW dataproduct_with_teamkatalogen_view;
+
+CREATE VIEW dataproduct_with_teamkatalogen_view AS(
+SELECT dp.*, tkt.name as team_name, tkpa.name as pa_name, tkt.product_area_id as pa_id FROM dataproducts dp LEFT JOIN 
+	(tk_teams tkt LEFT JOIN tk_product_areas tkpa
+	ON tkt.product_area_id = tkpa.id)
+	ON dp.team_id = tkt.id::text
+);
+
+CREATE VIEW dataproduct_view AS(
+    SELECT
+        dp.id as dp_id,
+        dp.name as dp_name,
+        dp.description as dp_description,
+        dp.group as dp_group,
+        dp.created as dp_created,
+        dp.last_modified as dp_last_modified,
+        dp.slug as dp_slug,
+        dp.teamkatalogen_url as teamkatalogen_url,
+        dp.team_contact as team_contact,
+        dp.team_id as team_id,
+		dp.team_name as team_name,
+		dp.pa_name as pa_name,
+        dp.pa_id as pa_id,
+        ds.dataproduct_id as ds_dp_id,
+        ds.id as ds_id,
+        ds.name as ds_name,
+        ds.description as ds_description,
+        ds.created as ds_created,
+        ds.last_modified as ds_last_modified,
+        ds.slug as ds_slug,
+        ds.keywords as ds_keywords
+    FROM
+        dataproduct_with_teamkatalogen_view dp
+        LEFT JOIN datasets ds ON dp.id = ds.dataproduct_id
+);
+
+-- +goose Down
+DROP VIEW dataproduct_view;
+DROP VIEW dataproduct_with_teamkatalogen_view;
+
+CREATE VIEW dataproduct_with_teamkatalogen_view AS(
+SELECT dp.*, tkt.name as team_name, tkpa.name as pa_name FROM dataproducts dp LEFT JOIN 
+	(tk_teams tkt LEFT JOIN tk_product_areas tkpa
+	ON tkt.product_area_id = tkpa.id)
+	ON dp.team_id = tkt.id::text
+);
+
+CREATE VIEW dataproduct_view AS(
+    SELECT
+        dp.id as dp_id,
+        dp.name as dp_name,
+        dp.description as dp_description,
+        dp.group as dp_group,
+        dp.created as dp_created,
+        dp.last_modified as dp_last_modified,
+        dp.slug as dp_slug,
+        dp.teamkatalogen_url as teamkatalogen_url,
+        dp.team_contact as team_contact,
+        dp.team_id as team_id,
+		dp.team_name as team_name,
+		dp.pa_name as pa_name,
+        ds.dataproduct_id as ds_dp_id,
+        ds.id as ds_id,
+        ds.name as ds_name,
+        ds.description as ds_description,
+        ds.created as ds_created,
+        ds.last_modified as ds_last_modified,
+        ds.slug as ds_slug,
+        ds.keywords as ds_keywords
+    FROM
+        dataproduct_with_teamkatalogen_view dp
+        LEFT JOIN datasets ds ON dp.id = ds.dataproduct_id
+);


### PR DESCRIPTION
Frontend link for exploring all products of a team has been broken after the backend rewrite as paID no longer was returned when fetching dataproduct metadata.

This commit will alter the dataproduct and dataproduct_with_teamkatalogen_view views to include the paID.