### PR TITLE
2188 metabase sync table visibility

### DIFF
--- a/pkg/database/gensql/querier.go
+++ b/pkg/database/gensql/querier.go
@@ -91,6 +91,7 @@ type Querier interface {
 	GetNadaToken(ctx context.Context, team string) (uuid.UUID, error)
 	GetNadaTokens(ctx context.Context) ([]NadaToken, error)
 	GetNadaTokensForTeams(ctx context.Context, teams []string) ([]NadaToken, error)
+	GetOpenMetabaseTablesInSameBigQueryDataset(ctx context.Context, arg GetOpenMetabaseTablesInSameBigQueryDatasetParams) ([]string, error)
 	GetOwnerGroupOfDataset(ctx context.Context, datasetID uuid.UUID) (string, error)
 	GetPollyDocumentation(ctx context.Context, id uuid.UUID) (PollyDocumentation, error)
 	GetProductArea(ctx context.Context, id uuid.UUID) (TkProductArea, error)

--- a/pkg/database/metabase_metadata.go
+++ b/pkg/database/metabase_metadata.go
@@ -55,6 +55,13 @@ func (r *Repo) GetAllMetabaseMetadata(ctx context.Context) ([]*models.MetabaseMe
 	return mbMetas, nil
 }
 
+func (r *Repo) GetOpenMetabaseTablesInSameBigQueryDataset(ctx context.Context, projectID, dataset string) ([]string, error) {
+	return r.Querier.GetOpenMetabaseTablesInSameBigQueryDataset(ctx, gensql.GetOpenMetabaseTablesInSameBigQueryDatasetParams{
+		ProjectID: projectID,
+		Dataset:   dataset,
+	})
+}
+
 func (r *Repo) SetPermissionGroupMetabaseMetadata(ctx context.Context, datasetID uuid.UUID, groupID int) error {
 	return r.Querier.SetPermissionGroupMetabaseMetadata(ctx, gensql.SetPermissionGroupMetabaseMetadataParams{
 		ID:        sql.NullInt32{Valid: true, Int32: int32(groupID)},

--- a/pkg/database/queries/metabase_metadata.sql
+++ b/pkg/database/queries/metabase_metadata.sql
@@ -48,3 +48,14 @@ WHERE "dataset_id" = @dataset_id;
 DELETE 
 FROM metabase_metadata
 WHERE "dataset_id" = @dataset_id;
+
+-- name: GetOpenMetabaseTablesInSameBigQueryDataset :many
+WITH sources_in_same_dataset AS (
+  SELECT * FROM datasource_bigquery 
+  WHERE project_id = @project_id AND dataset = @dataset
+)
+
+SELECT table_name FROM sources_in_same_dataset sds
+JOIN metabase_metadata mbm
+ON mbm.dataset_id = sds.dataset_id
+WHERE mbm.collection_id IS null;

--- a/pkg/metabase/client.go
+++ b/pkg/metabase/client.go
@@ -227,6 +227,17 @@ func (c *Client) HideTables(ctx context.Context, ids []int) error {
 	return c.request(ctx, http.MethodPut, "/table", t, nil)
 }
 
+func (c *Client) ShowTables(ctx context.Context, ids []int) error {
+	t := struct {
+		IDs            []int   `json:"ids"`
+		VisibilityType *string `json:"visibility_type"`
+	}{
+		IDs:            ids,
+		VisibilityType: nil,
+	}
+	return c.request(ctx, http.MethodPut, "/table", t, nil)
+}
+
 type Field struct{}
 
 type Table struct {

--- a/pkg/metabase/grant.go
+++ b/pkg/metabase/grant.go
@@ -280,7 +280,7 @@ func (m *Metabase) create(ctx context.Context, ds dsWrapper) error {
 		}
 	}
 
-	if err := m.HideOtherTables(ctx, &mbMeta, datasource); err != nil {
+	if err := m.SyncTableVisibility(ctx, &mbMeta, datasource); err != nil {
 		return err
 	}
 

--- a/pkg/metabase/grant.go
+++ b/pkg/metabase/grant.go
@@ -256,13 +256,14 @@ func (m *Metabase) create(ctx context.Context, ds dsWrapper) error {
 		return err
 	}
 
-	err = m.repo.CreateMetabaseMetadata(ctx, models.MetabaseMetadata{
+	mbMeta := models.MetabaseMetadata{
 		DatasetID:         ds.Dataset.ID,
 		DatabaseID:        dbID,
 		PermissionGroupID: ds.MetabaseGroupID,
 		CollectionID:      ds.CollectionID,
 		SAEmail:           ds.Email,
-	})
+	}
+	err = m.repo.CreateMetabaseMetadata(ctx, mbMeta)
 	if err != nil {
 		return err
 	}
@@ -279,7 +280,7 @@ func (m *Metabase) create(ctx context.Context, ds dsWrapper) error {
 		}
 	}
 
-	if err := m.HideOtherTables(ctx, dbID, datasource.Table); err != nil {
+	if err := m.HideOtherTables(ctx, &mbMeta, datasource); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Previously we have hidden all other tables in a bigquery dataset when adding a markedsplassen dataset to metabase. When the table is accessible by all users there exists a use case where users might want to join with other tables or views in the same bigquery dataset in metabase.

This PR re-adds and alters the sync we have had for hiding other tables in the same bigquery dataset to instead make all all-users accessible tables or views in the same bigquery dataset queryable in a metabase database.

Restricted datasets are handled the same way as earlier, i.e. all other tables/views in the same dataset are hidden.