### PR TITLE
Metabase permission graph updates

### DIFF
--- a/pkg/metabase/grant.go
+++ b/pkg/metabase/grant.go
@@ -269,7 +269,7 @@ func (m *Metabase) create(ctx context.Context, ds dsWrapper) error {
 	}
 
 	if ds.MetabaseGroupID > 0 {
-		err := m.client.RestrictAccessToDatabase(ctx, []int{ds.MetabaseGroupID}, dbID)
+		err := m.client.RestrictAccessToDatabase(ctx, ds.MetabaseGroupID, dbID)
 		if err != nil {
 			return err
 		}

--- a/pkg/service/access.go
+++ b/pkg/service/access.go
@@ -540,7 +540,7 @@ func GrantAccessToDataset(ctx context.Context, input GrantAccessData) *APIError 
 	if err != nil {
 		return NewAPIError(http.StatusInternalServerError, err, "grantAccessToDataset(): failed to grant access")
 	}
-	eventManager.TriggerDatasetGrant(ctx, input.DatasetID, subjWithType)
+
 	return nil
 }
 


### PR DESCRIPTION
This PR alters how the metabase group permissions are updated when a dataset is added. Instead of fetching the entire permission graph we now instead fetch only the permission object we need to alter on when updating the permission graph. 